### PR TITLE
edited requiremens.txt to fix gevent error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,9 +18,9 @@ Werkzeug==0.9.6
 alembic==0.6.7
 argparse==1.2.1
 backports.ssl-match-hostname==3.4.0.2
-gevent==1.0.1
+gevent==1.0.2
 gevent-websocket==0.9.3
-greenlet==0.4.4
+greenlet==0.4.9
 gunicorn==19.1.1
 httplib2==0.9
 itsdangerous==0.24


### PR DESCRIPTION
gevent version was throwing errors (SSL related). This is fixed with the new gevent version.
